### PR TITLE
View the website version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 *Have contributed in any way? Read how to put your name [here](https://github.com/ScratchAddons/contributors/issue/12).*
 
-*View the website version [here](https://github.com/ScratchAddons/contributors/).*
+*View the website version [here](https://scratchaddons.com/contributors/).*
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
View the website version link did not link to the SA website, but to this GitHub repo. This PR fixes that