### PR TITLE
Replace Chiroyce's profile with current GitHub

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1078,7 +1078,7 @@
       "login": "Chiroyce1",
       "name": "Chiroyce",
       "avatar_url": "https://avatars.githubusercontent.com/u/97374054?v=4",
-      "profile": "https://scratch.mit.edu/users/Chiroyce",
+      "profile": "https://github.com/Chiroyce1",
       "contributions": [
         "doc",
         "code"


### PR DESCRIPTION
As discussed on the Dev Discord server, hopefully this doesn't cause any conflicts with all-contributors when merged 