### PR TITLE
Add link to FAQ to issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Send Feedback
+    url: https://scratchaddons.com/docs/faq/#what-can-i-do-if-i-find-a-problem
+    about: Trying to leave feedback? Go here to learn more.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Contact Us
     url: https://scratchaddons.com/docs/faq/#what-can-i-do-if-i-find-a-problem
-    about: Want to say something about Scratch Addons? Learn more about how to reach/tell/contact us!
+    about: Want to say something about Scratch Addons? Learn more about how to reach us!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Send Feedback
     url: https://scratchaddons.com/docs/faq/#what-can-i-do-if-i-find-a-problem
-    about: Trying to leave feedback? Go here to learn more.
+    about: Want to say something about Scratch Addons? Learn more about how to reach/tell/contact us!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Send Feedback
+  - name: Contact Us
     url: https://scratchaddons.com/docs/faq/#what-can-i-do-if-i-find-a-problem
     about: Want to say something about Scratch Addons? Learn more about how to reach/tell/contact us!


### PR DESCRIPTION
Configures the [issue template chooser](https://github.com/ScratchAddons/contributors/issues/new/choose) to add a link to https://scratchaddons.com/docs/faq/#what-can-i-do-if-i-find-a-problem, which highlights the recommended options for leaving feedback about Scratch Addons.

There have been a few instances where people open issues here instead of on the ScratchAddons repository, where their feedback should go, perhaps because they were led here by the [credits page](https://scratchaddons.com/credits/).

Tested on a different repository.